### PR TITLE
updated deprecated apt calls

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,40 +1,53 @@
 - name: install desktop environment KDE
-  apt:  name={{ item }} state=present install_recommends=yes
-  with_items:
-    - kde-standard
-    - kde-plasma-desktop
+  apt:
+    pkg:
+      - kde-standard
+      - kde-plasma-desktop
+    state: present 
+    install_recommends: yes
   when: linux_desktop == 'kde'
 
 - name: install desktop environment Cinnamon
-  apt:  name={{ item }} state=present install_recommends=no
-  with_items:
-    - cinnamon-core
-    - libgl1-mesa-dri 
-    - x11-xserver-utils
-    - gnome-terminal
-    - lightdm
+  apt:
+    pkg:
+      - cinnamon-core
+      - libgl1-mesa-dri 
+      - x11-xserver-utils
+      - gnome-terminal
+      - lightdm
+    state: present 
+    install_recommends: no
   when: linux_desktop == 'cinnamon'
 
 - name: install desktop environment Gnome
-  apt:  name={{ item }} state=present install_recommends=no
-  with_items:
-    - gnome
+  apt:
+    pkg:
+      - gnome
+    state: present 
+    install_recommends: no
   when: linux_desktop == 'gnome'
 
 - name: install desktop environment Mate
-  apt:  name={{ item }} state=present install_recommends=no
-  with_items:
-    - mate-desktop-environment
-    - lightdm
+  apt:
+    pkg:
+      - mate-desktop-environment
+      - lightdm
+    state: present 
+    install_recommends: no
   when: linux_desktop == 'mate'
 
 - name: install desktop environment Xfce
-  apt:  name={{ item }} state=present install_recommends=no
-  with_items:
-    - xfce4
-    - xfce4-goodies
-    - lightdm
+  apt:
+    pkg:
+      - xfce4
+      - xfce4-goodies
+      - lightdm
+    state: present 
+    install_recommends: no
   when: linux_desktop == 'xfce'
 
 - name: install Xorg
-  apt: name='xorg' state=present
+  apt: 
+    pkg:
+      - xorg
+    state: present

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -6,6 +6,7 @@
     state: present 
     install_recommends: yes
   when: linux_desktop == 'kde'
+  become: yes
 
 - name: install desktop environment Cinnamon
   apt:
@@ -18,6 +19,7 @@
     state: present 
     install_recommends: no
   when: linux_desktop == 'cinnamon'
+  become: yes
 
 - name: install desktop environment Gnome
   apt:
@@ -26,6 +28,7 @@
     state: present 
     install_recommends: no
   when: linux_desktop == 'gnome'
+  become: yes
 
 - name: install desktop environment Mate
   apt:
@@ -35,6 +38,7 @@
     state: present 
     install_recommends: no
   when: linux_desktop == 'mate'
+  become: yes
 
 - name: install desktop environment Xfce
   apt:
@@ -45,9 +49,11 @@
     state: present 
     install_recommends: no
   when: linux_desktop == 'xfce'
+  become: yes
 
 - name: install Xorg
   apt: 
     pkg:
       - xorg
     state: present
+  become: yes


### PR DESCRIPTION
the old usage of apt caused the following warning
`[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ 
item }}"`, please use `name: ['cinnamon-core', 'libgl1-mesa-dri', 'x11-xserver-utils', 'gnome-terminal', 'lightdm']` and remove the loop. This feature will be removed in version
 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg`

so i have changed it to the newer way.